### PR TITLE
Fixed local imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "NODE_PATH=src jest",
+    "test": "jest",
     "test:coverage": "npm run test -- --collectCoverage",
     "lint": "tslint -t codeFrame -p .",
     "prepare": "npm run build",
@@ -37,6 +37,7 @@
     "dist"
   ],
   "dependencies": {
+    "callsites": "^3.1.0",
     "typescript": ">=1.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "main": "./dist/index.js",
   "engines": {
-    "node": "^10.14.0"
+    "node": ">=10.14.0"
   },
   "repository": {
     "type": "git",

--- a/src/lib/program.ts
+++ b/src/lib/program.ts
@@ -1,3 +1,5 @@
+import stack from 'callsites';
+import * as path from 'path';
 import * as ts from 'typescript';
 import { getOptions } from './options';
 
@@ -35,6 +37,14 @@ export const createInlineProgram = (code: string) => {
         ...compilerHost,
         getSourceFile,
     };
-    const program = ts.createProgram([FILENAME], options, customCompilerHost);
+
+    let filepath = FILENAME;
+    // index 2 is level (3 up in stack) where `inspect` function is called from
+    const callerFile = stack()[2]?.getFileName();
+    if (callerFile) {
+        filepath = path.resolve(path.dirname(callerFile), FILENAME);
+    }
+
+    const program = ts.createProgram([filepath], options, customCompilerHost);
     return { program, inlineSourceFile };
 };

--- a/src/test/inspect.test.ts
+++ b/src/test/inspect.test.ts
@@ -1,4 +1,4 @@
-import { inspect, inspectWithPreamble } from 'index';
+import { inspect, inspectWithPreamble } from '..';
 
 describe('inspect', () => {
     describe('inspectObjectCore', () => {
@@ -27,7 +27,7 @@ describe('inspect', () => {
         });
         test('Import', () => {
             const types = inspectWithPreamble(
-                "import { inspect } from 'index';"
+                "import { inspect } from '../index';"
             )({
                 res: 'typeof inspect',
             });
@@ -35,7 +35,7 @@ describe('inspect', () => {
         });
         test('Bad import', () => {
             expect(() =>
-                inspectWithPreamble("import { foo } from 'blah';")({
+                inspectWithPreamble("import { foo } from './blah';")({
                     res: 'typeof foo',
                 })
             ).toThrow();


### PR DESCRIPTION
Added check to figure out where `inspect` is being called from and append path to filename. 

This makes ts compiler to lookup modules from the directory where the code is being executed and resolve local modules correctly.

Fixes #3 